### PR TITLE
Use hasattr to check for inline.inlines

### DIFF
--- a/client_admin/admin.py
+++ b/client_admin/admin.py
@@ -181,7 +181,7 @@ class RecursiveInlinesModelAdmin(admin.ModelAdmin):
                 formset = FormSet(instance=self.model(), prefix=prefix,
                                   queryset=inline.queryset(request))
                 formsets.append(formset)
-                if inline.inlines:
+                if hasattr(inline, 'inlines'):
                     self.add_recursive_inline_formsets(request, inline, formset)
 
         adminForm = helpers.AdminForm(form, list(self.get_fieldsets(request)),


### PR DESCRIPTION
Fixes issue where mixing recursive and non-recursive inlines raises error on object add page
