### PR TITLE
Reverting 808d0963877f2cf0efdeaec7a2d574da01ced862

### DIFF
--- a/client_admin/static/client_admin/js/genericadmin.js
+++ b/client_admin/static/client_admin/js/genericadmin.js
@@ -5,8 +5,6 @@
 
     updated by Troy Melhase (troy.melhase@gmail.com)
 
-    updated by Elijah Hamovitz (elijah.hamovitz@gmail.com)
-
  */
  (function($) {
     var GenericAdmin = {
@@ -41,7 +39,7 @@
             var vars = $(this.object_input).attr("id").split('-');
             if (vars.length !== 1) {
                 //contentTypeSelect = $('#' + vars[0] + '-' + vars[1] + '-content_type').first();
-                contentTypeSelect = $('#' + $(this.object_input).attr("id").replace('object_id', 'content_type'))
+                contentTypeSelect = $('#' + $(this.object_input).attr("id").replace('-object_id', '-content_type'))
             }
             // polish the look of the select
             $(contentTypeSelect).find('option').each(function() {


### PR DESCRIPTION
Although that change did achieve the desired functionality, it also broke on related modules whose foreign key name contained the string "object_id", as with the CSky website PageModules. This is still desired functionality, but it should be achieved more carefully.
