### PR TITLE
Un-namespace jQuery in header

### DIFF
--- a/client_admin/static/admin/js/jquery.init.js
+++ b/client_admin/static/admin/js/jquery.init.js
@@ -1,0 +1,9 @@
+/* Puts the included jQuery into our own namespace using noConflict and passing
+ * it 'true'. This ensures that the included jQuery doesn't pollute the global
+ * namespace (i.e. this preserves pre-existing values for both window.$ and
+ * window.jQuery).
+ */
+var django = {
+    "jQuery": jQuery.noConflict(true)
+};
+jQuery = django.jQuery;


### PR DESCRIPTION
This allows widgets to load media in class Media.js = {...}

If a plugin depends on jQuery existing with it's normal name, then we have to use this approach to make sure jQuery is available.
