### PR TITLE
Fix retrieval of username to use method

### DIFF
--- a/client_admin/models.py
+++ b/client_admin/models.py
@@ -44,7 +44,7 @@ class DashboardPreferences(models.Model):
     dashboard_id = models.CharField(max_length=100)
 
     def __unicode__(self):
-        return "%s dashboard preferences" % self.user.username
+        return "%s dashboard preferences" % self.user.get_username()
 
     class Meta:
         db_table = 'client_admin_dashboard_preferences'


### PR DESCRIPTION
The username field does not necessarily exist on a subclass of
django.contrib.auth.models.AbstractBaseUser so dot notation would
break. Use of the method retrieve the value of the field specified by
the USERNAME_FIELD constant.
